### PR TITLE
refactor: Scrapy 세팅 파일 변경

### DIFF
--- a/osp/crawler/Scrapy/SKKU_GitHub/settings.py
+++ b/osp/crawler/Scrapy/SKKU_GitHub/settings.py
@@ -20,7 +20,7 @@ NEWSPIDER_MODULE = 'SKKU_GitHub.spiders'
 ROBOTSTXT_OBEY = False
 
 # Configure maximum concurrent requests performed by Scrapy (default: 16)
-CONCURRENT_REQUESTS = 16
+CONCURRENT_REQUESTS = 8
 
 # Configure a delay for requests for the same website (default: 0)
 # See https://docs.scrapy.org/en/latest/topics/settings.html#download-delay
@@ -89,3 +89,4 @@ ITEM_PIPELINES = {
 #HTTPCACHE_STORAGE = 'scrapy.extensions.httpcache.FilesystemCacheStorage'
 
 RETRY_HTTP_CODE = [429]
+REQUEST_FINGERPRINTER_IMPLEMENTATION = '2.7'


### PR DESCRIPTION
- 핑거프린트 버전 2.7로 지정하여 warning 제거
- CONCURRENT_REQUESTS를 8로 줄여 토큰 교체시 에러 감소