### PR TITLE
fix: 탈퇴한 유저의 게시물이 보이지 않는 버그 해결

### DIFF
--- a/osp/community/views.py
+++ b/osp/community/views.py
@@ -26,6 +26,7 @@ from user.models import Account, AccountPrivacy
 from user.serializers import AccountPrivacySerializer
 from rest_framework import status as http_status
 
+
 class TableBoardView(APIView):
     '''
     GET: 일반게시판, 팀 게시판, 팀 모집 게시판을 위한 JSON response
@@ -432,14 +433,14 @@ class UserArticlesView(APIView):
         # Request Validation
         status, message, errors, valid_data \
             = self.get_validation(request, *args, **kwargs)
-        
+
         if "require_login" in errors:
             message = 'validation 과정 중 오류가 발생하였습니다.'
             logging.exception(
                 f'TeamApplicationList validation error')
             res = {'status': status, 'message': message, 'errors': errors}
             return Response(res, status=http_status.HTTP_401_UNAUTHORIZED)
-        
+
         if status == 'fail':
             message = 'validation 과정 중 오류가 발생하였습니다.'
             logging.exception(f'UserArticlesView validation error')
@@ -591,7 +592,7 @@ class UserScrapArticlesView(APIView):
                 f'TeamApplicationList validation error')
             res = {'status': status, 'message': message, 'errors': errors}
             return Response(res, status=http_status.HTTP_401_UNAUTHORIZED)
-        
+
         if status == 'fail':
             message = 'validation 과정 중 오류가 발생하였습니다.'
             logging.exception(f'UserScrapArticlesView validation error')
@@ -1021,7 +1022,7 @@ class ArticleAPIView(APIView):
             article = valid_data['article']
 
             # 익명 또는 글쓴이가 아닌 유저가 조회할 때, 게시글 조회수 증가
-            if request.user.is_anonymous or article.writer.user_id != request.user.id:
+            if request.user.is_anonymous or not article.writer or article.writer.user_id != request.user.id:
                 article.view_cnt += 1
             article.save()
 
@@ -1303,7 +1304,8 @@ class ArticleUpdateView(APIView):
 
             # 홍보 게시판의 경우 Hero 홍보 게시 유무 업데이트
             if article.board.board_type == "Promotion":
-                hero_article = HeroArticle.objects.filter(article=article).first()
+                hero_article = HeroArticle.objects.filter(
+                    article=article).first()
                 hero_article_file = request.FILES.get('hero_thumbnail')
                 if is_hero and hero_article_file:
                     if hero_article:

--- a/osp/community/views.py
+++ b/osp/community/views.py
@@ -1021,7 +1021,7 @@ class ArticleAPIView(APIView):
         try:
             article = valid_data['article']
 
-            # 익명 또는 글쓴이가 아닌 유저가 조회할 때, 게시글 조회수 증가
+            # 익명 또는 탈퇴한 유저의 글 또는는 글쓴이가 아닌 유저가 조회할 때, 게시글 조회수 증가
             if request.user.is_anonymous or not article.writer or article.writer.user_id != request.user.id:
                 article.view_cnt += 1
             article.save()


### PR DESCRIPTION
탈퇴한 유저의 경우 해당 article의 user_id를 얻을 수 없기 때문에 조건문의 로직을 바꿔서 접근하지 못하도록 수정함