### PR TITLE
게시판 이름 및 정렬순서 변경

### DIFF
--- a/frontend/src/components/Community/Board/Board_Container.jsx
+++ b/frontend/src/components/Community/Board/Board_Container.jsx
@@ -7,7 +7,7 @@ import AuthContext from '../../../utils/auth-context';
 const server_url = import.meta.env.VITE_SERVER_URL;
 
 export default function Board_Container() {
-  // tabName으로 '자유', '질문', '정보', '홍보' 를 받아 게시판의 게시글 목록을 렌더링
+  // tabName으로 '홍보', '자유', '질문', '정보' 를 받아 게시판의 게시글 목록을 렌더링
   const navigate = useNavigate();
   const { tabName } = useParams();
   const [isLoadedArticles, setIsLoadedArticles] = useState(false);

--- a/frontend/src/components/Community/Board/Board_Presenter.jsx
+++ b/frontend/src/components/Community/Board/Board_Presenter.jsx
@@ -13,10 +13,10 @@ export default function Board_Presenter(props) {
     <div className="col-9">
       <div className="community-nav d-flex">
         <ul className="nav nav-fill">
-          <CommunityNavItem navName="자유" tabName={tabName} />
-          <CommunityNavItem navName="질문" tabName={tabName} />
-          <CommunityNavItem navName="정보" tabName={tabName} />
-          <CommunityNavItem navName="홍보" tabName={tabName} />
+          <CommunityNavItem navName="홍보" tabName={tabName} urlTabName="홍보" />
+          <CommunityNavItem navName="자유" tabName={tabName} urlTabName="자유" />
+          <CommunityNavItem navName="Q&A" tabName={tabName} urlTabName="질문" />
+          <CommunityNavItem navName="정보" tabName={tabName} urlTabName="정보" />
         </ul>
         {username === 'admin' ? (
           <button type="button" className="btn-write" onClick={onWrite}>

--- a/frontend/src/components/Community/Board/CommunityNavItem/CommunityNavItem_Container.jsx
+++ b/frontend/src/components/Community/Board/CommunityNavItem/CommunityNavItem_Container.jsx
@@ -2,12 +2,12 @@ import CommunityNavItem_Presenter from './CommunityNavItem_Presenter';
 import { useNavigate } from 'react-router-dom';
 
 export default function CommunityNavItem_Container(props) {
-  const { navName, tabName } = props;
+  const { navName, tabName, urlTabName } = props;
   const navigate = useNavigate();
-  const isActive = navName === tabName;
+  const isActive = urlTabName === tabName;
 
   const onNavigate = () => {
-    navigate(`./../${navName}`);
+    navigate(`./../${urlTabName}`);
   };
 
   return <CommunityNavItem_Presenter isActive={isActive} navName={navName} onNavigate={onNavigate} />;

--- a/frontend/src/components/Community/Board/MainBoard/MainBoard_Presenter.jsx
+++ b/frontend/src/components/Community/Board/MainBoard/MainBoard_Presenter.jsx
@@ -95,7 +95,7 @@ export default function Board_Presenter(props) {
   };
 
   const onCommunity = () => {
-    navigate(`/community/board/자유`);
+    navigate(`/community/board/홍보`);
   };
 
   const onRecruit = () => {
@@ -165,7 +165,7 @@ export default function Board_Presenter(props) {
                 }`}
                 onClick={() => handleTabClick1('질문')}
               >
-                <div>질문</div>
+                <div>Q&A</div>
               </li>
               <li
                 className={`board-nav-item ${

--- a/frontend/src/components/NavBar/HeadNavBar.jsx
+++ b/frontend/src/components/NavBar/HeadNavBar.jsx
@@ -6,7 +6,7 @@ function HeaderNavBar() {
   return (
     <div className="header-navbar">
       <Link
-        to="/community/board/자유"
+        to="/community/board/홍보"
         className={location == 'board' ? 'header-navbar-selected-menu' : 'header-navbar-menu'}
       >
         커뮤니티


### PR DESCRIPTION
커뮤니티 게시판 정렬 순서가 홍보/자유/Q&A/정보 순이 되도록 변경
메인화면과 커뮤니티 게시판 내에서의 순서 동일하게 변경
질문게시판 이름 Q&A 로 변경
상단바의 커뮤니티 버튼을 누르거나 메인화면 하단 글 목록에서 + 버튼을 눌러서 커뮤니티 게시판으로 진입할 때 초기화면이 자유게시판->홍보게시판이 되도록 변경