### PR TITLE
팀 지원 시 거절이 안되는 버그 픽스

### DIFF
--- a/frontend/src/components/NavBar/TeamApplication/TeamApplication.jsx
+++ b/frontend/src/components/NavBar/TeamApplication/TeamApplication.jsx
@@ -91,7 +91,7 @@ const TeamApplication = ({ handleClose, show }) => {
   };
 
   const handleRefuseClick = (applyId, userId) => {
-    sendTeamApplication(applyId, userId, 'false');
+    sendTeamApplication(applyId, userId, '-1');
     setReceived((prev) => prev.filter((app) => app.id !== applyId));
   };
 
@@ -131,7 +131,8 @@ const TeamApplication = ({ handleClose, show }) => {
                 <div className="d-flex">
                   <div className="me-2">
                     {' '}
-                    {application.team.name} {application.team.id}{' '}
+                    {/* {application.team.name} {application.team.id}{' '} */}
+                    {application.team.name}{' '}
                   </div>
                   <Link onClick={() => clickUsername(application.account.user.username)}>
                     {application.account.user.username}
@@ -191,13 +192,18 @@ const TeamApplication = ({ handleClose, show }) => {
               >
                 <div>{application.team.name}</div>
                 <div className="d-flex flex-row">
+                <p>현재 상태 값: {application.status ?? "알 수 없음"}</p> {/* 상태 출력 */}
                   {application.status === 1 ? (
                     <Badge bg="primary" className="text-center text-left fs-6 me-2 lh-sm">
                       승인됨
                     </Badge>
-                  ) : (
+                  ) : application.status === -1 ? (
                     <Badge bg="danger" className="text-center text-left fs-6 me-2 lh-sm">
                       거절됨
+                    </Badge>
+                  ) : (
+                    <Badge bg="secondary" className="text-center text-left fs-6 me-2 lh-sm">
+                      대기중
                     </Badge>
                   )}
                   <Button

--- a/frontend/src/components/NavBar/TeamApplication/TeamApplication.jsx
+++ b/frontend/src/components/NavBar/TeamApplication/TeamApplication.jsx
@@ -192,7 +192,6 @@ const TeamApplication = ({ handleClose, show }) => {
               >
                 <div>{application.team.name}</div>
                 <div className="d-flex flex-row">
-                <p>현재 상태 값: {application.status ?? "알 수 없음"}</p> {/* 상태 출력 */}
                   {application.status === 1 ? (
                     <Badge bg="primary" className="text-center text-left fs-6 me-2 lh-sm">
                       승인됨

--- a/osp/team/views.py
+++ b/osp/team/views.py
@@ -1426,7 +1426,7 @@ class TeamApplyUpdateView(APIView):
                     TeamMember.objects.create(
                         team=teamapplymessage.team, member_id=target_user_id)
                 else:
-                    teamapplymessage.status = 2  # 거절
+                    teamapplymessage.status = -1  # 거절
                 teamapplymessage.save()
 
         except DatabaseError as e:


### PR DESCRIPTION
팀 지원 시 응답과 관련없이 거절이 되는 버그를 해결하였습니다.

- 팀 지원 시 응답을 기다리는 "대기 중" 상태 추가
- 팀 승락/거절 시 보내는 상태 코드 변경 