### PR TITLE
[fix] 깃허브 핸들 변경 모달 창에서 임의의 깃허브 아이디를 입력 가능한 취약점 해결

### DIFF
--- a/frontend/src/components/Account/GithubLoginModal.jsx
+++ b/frontend/src/components/Account/GithubLoginModal.jsx
@@ -5,10 +5,9 @@ import Modal from 'react-bootstrap/Modal';
 import Button from 'react-bootstrap/Button';
 
 const GithubLoginModal = (props) => {
-  const { show, onClose, onSubmitGithubId } = props;
+  const { show, loginUsername, onClose, onSubmitGithubId } = props;
   const navigate = useNavigate();
   const [studentId, setStudentId] = useState('');
-  const [githubId, setGithubId] = useState('');
   const [error, setError] = useState(null);
   const githubInputRef = useRef();
 
@@ -18,19 +17,16 @@ const GithubLoginModal = (props) => {
   };
 
   const handleSubmit = () => {
-    if (!studentId || !githubId) {
-      setError('학번과 GitHub ID를 모두 입력해주세요.');
+    if (!studentId) {
+      setError('학번을 입력해주세요.');
       return;
     }
-
-    onSubmitGithubId(studentId, githubId);
     onClose(false);
   };
 
   useEffect(() => {
     if (show) {
       setStudentId('');
-      setGithubId('');
       setError(null);
     }
   }, [show]);
@@ -50,17 +46,6 @@ const GithubLoginModal = (props) => {
                 placeholder="학번을 입력해주세요"
                 value={studentId}
                 onChange={(e) => setStudentId(e.target.value)}
-                required
-              />
-            </Form.Group>
-            <Form.Group className="mb-3">
-              <Form.Label>GitHub ID</Form.Label>
-              <Form.Control
-                type="text"
-                placeholder="변경하고자 하는 GitHub ID를 입력해주세요"
-                value={githubId}
-                onChange={(e) => setGithubId(e.target.value)}
-                ref={githubInputRef}
                 required
               />
             </Form.Group>

--- a/frontend/src/components/Account/GithubLoginModal.jsx
+++ b/frontend/src/components/Account/GithubLoginModal.jsx
@@ -21,6 +21,7 @@ const GithubLoginModal = (props) => {
       setError('학번을 입력해주세요.');
       return;
     }
+    onSubmitGithubId(studentId, loginUsername);
     onClose(false);
   };
 
@@ -47,6 +48,15 @@ const GithubLoginModal = (props) => {
                 value={studentId}
                 onChange={(e) => setStudentId(e.target.value)}
                 required
+              />
+            </Form.Group>
+            <Form.Group className="mb-3">
+              <Form.Label>GitHub ID</Form.Label>
+              <Form.Control
+                type="text"
+                placeholder="변경하고자 하는 GitHub ID를 입력해주세요"
+                value={loginUsername}
+                disabled={true}
               />
             </Form.Group>
             {error && <p style={{ color: 'red' }}>{error}</p>}

--- a/frontend/src/components/Account/OAuth.jsx
+++ b/frontend/src/components/Account/OAuth.jsx
@@ -96,7 +96,7 @@ function OAuth() {
       {showModal && modalData && (
         <GitHubLoginModal
           show={showModal}
-          loginUsername={modalData?.github_username}
+          loginUsername={modalData?.github_username.value}
           onClose={setShowModal}
           onSubmitGithubId={handleGithubIdChange}
         />

--- a/frontend/src/components/Account/OAuth.jsx
+++ b/frontend/src/components/Account/OAuth.jsx
@@ -85,7 +85,7 @@ function OAuth() {
       })
       .catch((error) => {
         console.error('GitHub ID 변경 오류:', error);
-        alert('GitHub ID 변경 도중 오류가 발생하였습니다.');
+        alert('GitHub ID 변경 도중 오류가 발생하였습니다. 학번이 올바른지 확인해주세요.');
         navigate('/accounts/login');
       });
   };

--- a/frontend/src/components/Account/OAuth.jsx
+++ b/frontend/src/components/Account/OAuth.jsx
@@ -41,7 +41,6 @@ function OAuth() {
               const isValid = Object.values(res.data).every((value) => value !== null);
               if (isValid) {
                 if (confirm(res.message)) {
-                  // Github ID 변경
                   setModalData(res.data);
                   setShowModal(true);
                 } else {
@@ -95,7 +94,12 @@ function OAuth() {
     <>
       <LoaderIcon style={{ marginTop: '50px' }} />
       {showModal && modalData && (
-        <GitHubLoginModal show={showModal} onClose={setShowModal} onSubmitGithubId={handleGithubIdChange} />
+        <GitHubLoginModal
+          show={showModal}
+          loginUsername={modalData?.github_username}
+          onClose={setShowModal}
+          onSubmitGithubId={handleGithubIdChange}
+        />
       )}
     </>
   );

--- a/osp/common/views.py
+++ b/osp/common/views.py
@@ -628,7 +628,7 @@ class GithubIdChangeView(APIView):
         if student_data.exists():
             student_data = student_data.first()
         else:
-            return Response(get_fail_res("학번을 다시 확인해주세요."))
+            return Response(get_fail_res("학번을 다시 확인해주세요."), status=status.HTTP_404_NOT_FOUND)
         print(student_data)
         print(student_data.github_id)
         if (data.get('github_id') != student_data.github_id):


### PR DESCRIPTION
기존에는 사용자의 입력을 받아서 변경했지만, 사용자가 마음만 먹으면 다른 사람의 핸들을 입력하고 그 데이터를 크롤링해서 부당하게 점수를 높힐 수 있었던 취약점이 존재했습니다.

이제는 github api 에서 받아온 username을 그대로 활용하게 해서 유저가 임의로 조작하지 못하게 변경하였습니다.