### PR TITLE
개발자유형 페이지 수정

### DIFF
--- a/frontend/src/components/User/TypeTest/DevType.jsx
+++ b/frontend/src/components/User/TypeTest/DevType.jsx
@@ -108,7 +108,8 @@ function DevType(props) {
   }, []);
 
   // stats가 없을 경우 기본값으로 maxCount를 설정
-  const maxCount = stats.length > 0 ? Math.max(...stats.map(stat => stat.count)) * 1.2 : 100;
+  const rawMax = stats.length > 0 ? Math.max(...stats.map(stat => stat.count)) : 100;
+  const maxCount = Math.ceil(rawMax * 1.2);
 
   const chartData = {
     labels: stats.map((stat, index) => `${index + 1}. ${stat.koreanType}`),
@@ -152,7 +153,10 @@ function DevType(props) {
         beginAtZero: true,
         grid: { display: false },
         ticks: {
-          callback: (value) => `${value}명`,
+          callback: (value) => {
+            if (value > rawMax) return '';
+            return `${value}명`;
+          }
         },
         max: maxCount,
       },

--- a/frontend/src/components/User/TypeTest/DevTypeCard.jsx
+++ b/frontend/src/components/User/TypeTest/DevTypeCard.jsx
@@ -1,4 +1,5 @@
 import ResultProgress from './ResultProgress';
+import ImageDescBox from './ImageDescBox';
 
 function DevTypeCard(props) {
   const devType = props.devType;
@@ -13,14 +14,20 @@ function DevTypeCard(props) {
       <div id="gbti-id-card-content" className="modal-gbti-card">
         <div className="weak-text ms-3 text-start">SOSD ID CARD</div>
         <div className="d-flex justify-content-center">
-          <div className="gbti-content d-flex justify-content-center" style={{ padding: '1% 4%', width: '50%' }}>
-            <img src={devType} className="gbti-img" />
+          <div className="gbti-content d-flex justify-content-center" style={{ padding: '2%', width: '50%' }}>
+            {/* <img src={devType} className="gbti-img" /> */}
+            <ImageDescBox
+              src={devType}
+              title={typeKr}
+              desc={descKr}
+              attrs={descEng.split(' ')}
+            />
           </div>
           <div
             className="gbti-content d-flex flex-column justify-content-between"
             style={{ padding: '1% 4%', width: '50%' }}
           >
-            <p
+            {/* <p
               id="descEng"
               className="text-center text-label"
               style={{ fontSize: '12px', marginBottom: '2px', fontWeight: '600', fontFamily: "nanumfont_Bold"}}
@@ -29,7 +36,7 @@ function DevTypeCard(props) {
             </p>
             <p id="descKr" className="text-center text-label mb-1" style={{ fontSize: '14px', fontWeight: '600', fontFamily: "nanumfont_Bold" }}>
               {descKr}
-            </p>
+            </p> */}
             <h4 id="typeEng" className="text-center" style={{fontFamily: "nanumfont_Bold"}}>
               {typeEng}
             </h4>

--- a/frontend/src/components/User/TypeTest/ImageDescBox.jsx
+++ b/frontend/src/components/User/TypeTest/ImageDescBox.jsx
@@ -10,22 +10,39 @@ function ImageDescBox(props) {
   };
 
   return (
-    <div className="desc-box" style={bgImgStyle}>
+    <div className="desc-box" style={{ ...bgImgStyle, width: '100%' }}>
       <div className="text-center mt-5">
         <span className="badge text-bg-light fs-5 bold">{title}</span>
       </div>
 
-      <div className="desc-textbox">
+      <div className="desc-textbox" style={{ textAlign: "left"}}>
         <div className="desc-img">
           <img src={src} className="desc-center-img" />
         </div>
-        {attrs &&
+        {/* {attrs &&
           attrs.map((attr) => (
             <span key={attr} className="badge text-bg-light fs-7" style={{fontFamily: "nanumfont_Bold"}}>
               #{attr}
             </span>
-          ))}
-        <p className="fs-6" style={{fontFamily: "nanumfont_Bold"}}>{desc}</p>
+          ))} */}
+        {attrs && (
+          <>
+            <span className="badge text-bg-light fs-7" style={{ fontFamily: "nanumfont_Bold" }}>
+              #{attrs[3]}
+            </span>
+            <span className="badge text-bg-light fs-7" style={{ fontFamily: "nanumfont_Bold" }}>
+              #{attrs[2]}
+            </span>
+            <br />
+            <span className="badge text-bg-light fs-7" style={{ fontFamily: "nanumfont_Bold" }}>
+              #{attrs[1]}
+            </span>
+            <span className="badge text-bg-light fs-7" style={{ fontFamily: "nanumfont_Bold" }}>
+              #{attrs[0]}
+            </span>
+          </>
+        )}
+        <p className="fs-7" style={{fontFamily: "nanumfont_Bold", marginTop: "16px"}}>{desc}</p>
       </div>
     </div>
   );


### PR DESCRIPTION
+ 단순 색상 -> 하단과 동일하게 유형 정보 표현 & 우측 간소화
+ attribute(#)가 mbti 순서대로, 한 줄에 두개씩 정렬되어 출력되도록 수정
+ 하단 텍스트도 한 줄 안에 깔끔하게 출력되도록 수정

+ 통계 그래프 하단 소수점으로 표기되는 문제 해결

(기존)
![image](https://github.com/user-attachments/assets/4ca9e8b7-28dc-4fa2-8e5f-6a81d376aa80)

(수정)
![image](https://github.com/user-attachments/assets/94d91d7d-1f2c-4241-9399-e9b9021f05f1)
![image](https://github.com/user-attachments/assets/be6b3dd0-4fc9-47cc-a268-8a04100354ed)
