### PR TITLE
모바일 UI 개선 (댓글, footer)

### DIFF
--- a/frontend/src/components/Community/Article/ArticleEdit/ArticleEdit.css
+++ b/frontend/src/components/Community/Article/ArticleEdit/ArticleEdit.css
@@ -258,9 +258,18 @@
 .comment-input {
   padding: 10px 0;
   display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.comment-count {
+  width: 100%;
+}
+
+.comment-write {
+  display: flex;
   align-items: center;
-  justify-content: space-between;
-  flex-grow: 1;
+  gap: 10px;
 }
 
 .comment {

--- a/frontend/src/components/Community/Article/TinyArticle/Comment.jsx
+++ b/frontend/src/components/Community/Article/TinyArticle/Comment.jsx
@@ -34,29 +34,32 @@ function Comment(props) {
     <div className="comment-container">
       {username && (
         <div className="comment-input">
-          <div>
+          <div className="comment-count">
             <span className="article-info mx-1">
               <BsChatLeft size={22} style={{ margin: '3px' }} />({data.comments.length})
             </span>
           </div>
-          <Form.Check
-            type="checkbox"
-            label="익명"
-            checked={isAnonymous}
-            onChange={(e) => setIsAnonymous(e.target.checked)}
-          />
-          <div className="flex-grow-1 mx-1">
-            <Form.Control
-              type="text"
-              placeholder="댓글을 입력하세요"
-              value={comment}
-              onChange={(e) => setComment(e.target.value)}
-              style={{ backgroundColor: '#e7e7e7', borderRadius: '20px' }}
+
+          <div className='comment-write'>
+            <Form.Check
+              type="checkbox"
+              label="익명"
+              checked={isAnonymous}
+              onChange={(e) => setIsAnonymous(e.target.checked)}
             />
+            <div className="flex-grow-1 mx-1">
+              <Form.Control
+                type="text"
+                placeholder="댓글을 입력하세요"
+                value={comment}
+                onChange={(e) => setComment(e.target.value)}
+                style={{ backgroundColor: '#e7e7e7', borderRadius: '20px' }}
+              />
+            </div>
+            <button className="btn-write" onClick={() => postComment()}>
+              작성
+            </button>
           </div>
-          <button className="btn-write" onClick={() => postComment()}>
-            작성
-          </button>
         </div>
       )}
       {data.comments.map((comment) => (

--- a/frontend/src/components/NavBar/MainFooter.css
+++ b/frontend/src/components/NavBar/MainFooter.css
@@ -1,3 +1,9 @@
+@media (max-width: 768px) {
+  .mobile-br { display: inline !important; }
+}
+
+.mobile-br { display: none; }
+
 .footer {
   height: 60px;
   padding: 15px;

--- a/frontend/src/components/NavBar/MainFooter_Presenter.jsx
+++ b/frontend/src/components/NavBar/MainFooter_Presenter.jsx
@@ -21,7 +21,7 @@ function MainHeader_Presenter() {
               title="개인정보처리방침 바로가기"
               style={{ color: '#8dc63f' }}
             >
-              개인정보처리방침
+              개인정보<br className="mobile-br" />처리방침
             </a>
           </li>
           <li>
@@ -31,7 +31,7 @@ function MainHeader_Presenter() {
               title="네티즌윤리규약 바로가기"
               style={{ color: '#bfbfbf' }}
             >
-              네티즌윤리규약
+              네티즌<br className="mobile-br" />윤리규약
             </a>
           </li>
           <li>
@@ -41,7 +41,7 @@ function MainHeader_Presenter() {
               title="이메일무단수집거부 바로가기"
               style={{ color: '#bfbfbf' }}
             >
-              이메일무단수집거부
+              이메일무단<br className="mobile-br" />수집거부
             </a>
           </li>
         </ul>


### PR DESCRIPTION
## 📌 PR 개요

댓글과 footer의 모바일 UI를 개선했습니다.

## 🖼 스크린샷 (선택)

### 커뮤니티 댓글 (PC, 모바일 모두 수정)

모바일 변경 전)
<img width="429" height="219" alt="image" src="https://github.com/user-attachments/assets/c7de223a-b888-48de-a817-558c5685f6f9" />

모바일 변경 후)
<img width="416" height="207" alt="image" src="https://github.com/user-attachments/assets/ef33858b-eef2-4490-b546-2be9a0d4883d" />

PC 변경 전)
<img width="915" height="101" alt="image" src="https://github.com/user-attachments/assets/dd449e8a-fcc0-44f4-b08a-2c1785ffb245" />

PC 변경 후)
<img width="930" height="136" alt="image" src="https://github.com/user-attachments/assets/56fe1696-093f-4a86-8121-eb6f221512e5" />


### 하단 footer

변경 전)
<img width="423" height="78" alt="image" src="https://github.com/user-attachments/assets/2c9d6177-fcbf-46f3-91e4-f64ba1153a7f" />


변경 후)
<img width="441" height="97" alt="image" src="https://github.com/user-attachments/assets/ff95ee65-ba8d-41cf-af5f-dad880cee6f4" />

