### PR TITLE
릴리즈 기반 상용서버 자동 배포 설정

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -11,14 +11,14 @@ jobs:
 
     steps:
       - name: Pull latest code from develop branch
+        working-directory: /home/sosd-dev/SKKU-OSP_FB
         run: |
-          cd /home/sosd-dev/SKKU-OSP_FB
           git checkout develop
           git pull origin develop
 
       - name: Deploy with Docker Compose
+        working-directory: /home/sosd-dev/SKKU-OSP_FB/deploy/dev
         run: |
-          cd /home/sosd-dev/SKKU-OSP_FB/deploy/dev
           docker compose down
           docker compose up -d --build
 

--- a/.github/workflows/main-deploy-on-release.yml
+++ b/.github/workflows/main-deploy-on-release.yml
@@ -1,0 +1,44 @@
+name: 운영 서버 릴리즈 기반 자동 배포
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  deploy:
+    runs-on: self-hosted
+
+    steps:
+      - name: Pull released code from main branch
+        run: |
+          cd /home/sosd-dev/SKKU-OSP
+          git checkout main
+          git pull origin main
+
+      - name: Deploy with Docker Compose (Production)
+        run: |
+          cd /home/sosd-dev/SKKU-OSP/deploy/prod
+          docker compose down
+          FRONTEND_VERSION=${{ github.event.release.tag_name }} BACKEND_VERSION=${{ github.event.release.tag_name }} docker compose up -d --build
+
+      - name: Notify Slack on Success
+        if: success()
+        run: |
+          curl -X POST https://slack.com/api/chat.postMessage \
+            -H "Authorization: Bearer ${{ secrets.SLACK_BOT_TOKEN }}" \
+            -H "Content-type: application/json; charset=utf-8" \
+            --data '{
+              "channel": "#sosd-deploy",
+              "text": "✅ [운영 배포 성공] 릴리즈 `${{ github.event.release.tag_name }}` 버전이 성공적으로 배포되었습니다.\n🔗 https://sosd.skku.edu"
+            }'
+
+      - name: Notify Slack on Failure
+        if: failure()
+        run: |
+          curl -X POST https://slack.com/api/chat.postMessage \
+            -H "Authorization: Bearer ${{ secrets.SLACK_BOT_TOKEN }}" \
+            -H "Content-type: application/json; charset=utf-8" \
+            --data '{
+              "channel": "#sosd-deploy",
+              "text": "❌ [운영 배포 실패] 릴리즈 `${{ github.event.release.tag_name }}` 배포에 실패했습니다. 로그를 확인해주세요.\n🔗 https://github.com/SKKU-OSP/SKKU-OSP/actions"
+            }'

--- a/.github/workflows/main-deploy-on-release.yml
+++ b/.github/workflows/main-deploy-on-release.yml
@@ -10,14 +10,14 @@ jobs:
 
     steps:
       - name: Pull released code from main branch
+        working-directory: /home/sosd-dev/SKKU-OSP
         run: |
-          cd /home/sosd-dev/SKKU-OSP
           git checkout main
           git pull origin main
 
       - name: Deploy with Docker Compose (Production)
+        working-directory: /home/sosd-dev/SKKU-OSP/deploy/prod
         run: |
-          cd /home/sosd-dev/SKKU-OSP/deploy/prod
           docker compose down
           FRONTEND_VERSION=${{ github.event.release.tag_name }} BACKEND_VERSION=${{ github.event.release.tag_name }} docker compose up -d --build
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -19,19 +19,39 @@ deploy/
 
 ```bash
 cd deploy/dev
+docker-compose down
 docker-compose up -d --build
 ```
 
 ## 상용서버 배포
 
-상용서버는 반드시 배포 버전을 명시해야 합니다.
+상용서버 배포는 두 가지 방식으로 수행할 수 있습니다.
 
-### 버전 지정 배포
+### ① 수동 배포 (버전 명시 필요)
+
+운영 서버에서는 반드시 **버전을 명시**하고 배포해야 합니다.
 
 ```bash
 cd deploy/prod
+docker-compose down
 FRONTEND_VERSION=v1.0.8 BACKEND_VERSION=v1.0.8 docker-compose up -d --build
 ```
+
+### ② 자동 배포 (릴리즈 기반)
+
+- `main` 브랜치 기준으로 GitHub에서 릴리즈를 생성하고 **Publish** 하면,
+- GitHub Actions self-hosted runner를 통해 운영 서버에 자동으로 배포됩니다.
+- 이때 릴리즈 태그(`v1.0.8` 등)가 `FRONTEND_VERSION`, `BACKEND_VERSION`으로 자동 전달됩니다.
+
+#### 자동 배포 흐름:
+
+1. `develop` → `main` PR 머지
+2. GitHub에서 릴리즈 생성 (`v1.0.8`)
+3. 릴리즈 노트 수동 작성 후 `Publish`
+4. 운영 서버에 자동 배포 실행
+
+- 배포 상태 확인: https://github.com/SKKU-OSP/SKKU-OSP/actions
+- 자동 배포는 오직 **main 브랜치 릴리즈**만 트리거됩니다.
 
 ## 서비스 확인
 
@@ -55,7 +75,7 @@ docker-compose down
 
 ## 접속 정보
 
-- **개발서버**: https://sosd-dev.skku.edu:8080
+- **개발서버**: https://sosd-dev.skku.edu:8080 (VPN 필요)
 - **상용서버**: https://sosd.skku.edu
 
 ## 주의사항

--- a/deploy/prod/docker-compose.yml
+++ b/deploy/prod/docker-compose.yml
@@ -5,8 +5,8 @@ services:
   FRONTEND:
     # 빌드와 이미지 둘 다 지정 가능
     build:
-      context: ../../
-      dockerfile: frontend/Dockerfile
+      context: ../../frontend
+      dockerfile: Dockerfile
       args:
         BUILD_ENV: PRODUCT
     image: sosd/sosd-frontend-vitejs:${FRONTEND_VERSION:-v1.0.7}
@@ -25,8 +25,8 @@ services:
 
   OSP:
     build:
-      context: ../../
-      dockerfile: osp/Dockerfile
+      context: ../../osp
+      dockerfile: Dockerfile
       args:
         BUILD_ENV: PRODUCT
     image: sosd/sosd-backend-django:${BACKEND_VERSION:-v1.0.7}


### PR DESCRIPTION
## 📌 PR 개요

릴리즈 배포 시 상용서버가 자동으로 태그를 가져와 배포하도록 설정

## 🛠 작업 내용

- [ ] 상용서버 배포 명령어 변경
기존의 build를 docker-compose 안에서 처리하도록 변경
- [ ] 릴리즈 기반으로 자동배포 설정
새로운 릴리즈 버전을 publish 하면 서버에서 자동으로 최신 브랜치를 가져와 배포 진행

서버가 VPN으로 외부에서 접근할 수 없기 때문에 개발서버와 마찬가지로 self hosted runner를 이용했습니다.
