### PR TITLE
feat: replace Scrapy tables with Spring MySQL VIEWs for issues, pulls…

### DIFF
--- a/osp/repository/models.py
+++ b/osp/repository/models.py
@@ -54,7 +54,7 @@ class GithubRepoStats(models.Model):
 
     class Meta:
         managed = False
-        db_table = 'github_repo_stats'
+        db_table = 'v_github_repo_stats'
         unique_together = (('github_id', 'repo_name'),)
 
     def get_guideline(self):
@@ -103,7 +103,7 @@ class GithubIssues(models.Model):
 
     class Meta:
         managed = False
-        db_table = 'github_issues'
+        db_table = 'v_github_issues'
         unique_together = (('owner_id', 'repo_name', 'number'),)
 
 
@@ -117,7 +117,7 @@ class GithubPulls(models.Model):
 
     class Meta:
         managed = False
-        db_table = 'github_pulls'
+        db_table = 'v_github_pulls'
         unique_together = (('owner_id', 'repo_name', 'number'),)
 
 


### PR DESCRIPTION
📌 PR 개요
Scrapy 수집 데이터 테이블을 Spring 수집 데이터 기반 MySQL VIEW로 교체합니다.
기존에는 OSP Django 모델이 Scrapy가 채운 테이블을 직접 읽었지만, Spring 수집기로 전환하면서 동일한 스키마를 제공하는 VIEW를 생성하여 OSP 코드 변경을 최소화했습니다.

🛠 작업 내용
 개발/상용 서버 DB에 MySQL VIEW 3개 생성
v_github_issues: github_issue + github_repository + github_account JOIN
v_github_pulls: github_pull_request + github_repository + github_account JOIN
v_github_repo_stats: github_repository 기반 (prs_count 합산, readme 0/1 변환)
 repository/models.py db_table 변경 (3개 모델)
GithubIssues: github_issues → v_github_issues
GithubPulls: github_pulls → v_github_pulls
GithubRepoStats: github_repo_stats → v_github_repo_stats
🔗 연관된 이슈
없음

## ❓ 기타 의견
