### PR TITLE
Feat/spring scrapy replace statsyymm

### DIFF
--- a/osp/user/models.py
+++ b/osp/user/models.py
@@ -60,7 +60,7 @@ class GithubStatsYymm(models.Model):
 
     class Meta:
         managed = False
-        db_table = 'github_stats_yymm'
+        db_table = 'github_monthly_stats'
 
     def to_json(self):
         return {

--- a/osp/user/views.py
+++ b/osp/user/views.py
@@ -836,9 +836,9 @@ def get_user_star(github_id: str):
     star_subquery = Subquery(StudentTab.objects.values('github_id'))
     # repo_name, owner_id, github_id 값 비교
     where_stmt = [
-        "github_repo_contributor.repo_name=github_repo_stats.repo_name",
-        "github_repo_contributor.owner_id=github_repo_stats.github_id",
-        "github_repo_contributor.github_id=github_repo_stats.github_id"]
+        "github_repo_contributor.repo_name=v_github_repo_stats.repo_name",
+        "github_repo_contributor.owner_id=v_github_repo_stats.github_id",
+        "github_repo_contributor.github_id=v_github_repo_stats.github_id"]
     star_data = GithubRepoStats.objects.filter(github_id__in=star_subquery).extra(
         tables=['github_repo_contributor'], where=where_stmt).values('github_id').annotate(star=Sum("stargazers_count"))
     total_stars = sum(item['star'] for item in star_data)


### PR DESCRIPTION
📌 PR 개요
월별 기여 통계 데이터 소스를 Scrapy 크롤러(github_stats_yymm)에서 Spring 수집기(github_monthly_stats)로 교체하고, 이 과정에서 발생한 대시보드 500 에러를 함께 수정합니다.

🛠 작업 내용
 GithubStatsYymm 모델의 db_table을 github_stats_yymm → github_monthly_stats로 변경
Spring이 GitHub API에서 수집한 커밋/PR/이슈를 월별로 집계한 테이블
OSP 호환 컬럼명(num_of_PRs 등) 유지
 get_user_star() 뷰에서 .extra(where=[...]) 내 하드코딩된 테이블명 수정
github_repo_stats → v_github_repo_stats (이전 PR에서 VIEW로 전환된 테이블명 반영)
미수정 시 대시보드 접속 시 500 에러 발생

🖼 스크린샷 (선택)

🔗 연관된 이슈
closes #

❓ 기타 의견
github_monthly_stats 테이블은 Spring 앱이 실행 중이어야 존재합니다. Spring 배포 후 OSP를 배포해야 합니다.