### PR TITLE
Feat/spring scrapy replace repocommits

### DIFF
--- a/osp/common/views.py
+++ b/osp/common/views.py
@@ -25,7 +25,7 @@ from osp.settings import (EMAIL_HOST_USER, GITHUB_CLIENT_ID,
 from tag.models import TagIndependent
 from tag.serializers import TagIndependentSerializer
 from user.models import Account, AccountInterest, AccountPrivacy, StudentTab, GitHubScoreTable, GithubScore, GithubStatsYymm, GithubUserFollowing, GithubUserStarred, GithubOverview
-from repository.models import GithubIssues, GithubPulls, GithubRepoCommits, GithubRepoContributor, GithubRepoStats, GithubRepoCommitFiles, GithubRepoStatsyymm, GithubStars
+from repository.models import GithubRepoContributor, GithubRepoCommitFiles, GithubRepoStatsyymm, GithubStars
 from home.models import Repository, Student
 from data.api import GitHub_API
 from django.views.decorators.csrf import csrf_exempt
@@ -641,23 +641,14 @@ class GithubIdChangeView(APIView):
                 students = Student.objects.filter(github_id=old_owner)
                 student_tabs = StudentTab.objects.filter(github_id=old_owner)
                 account = Account.objects.filter(github_id=old_owner)
-                github_issues = GithubIssues.objects.filter(
-                    github_id=old_owner)
                 github_overview = GithubOverview.objects.filter(
                     github_id=old_owner)
-                github_pulls = GithubPulls.objects.filter(github_id=old_owner)
                 github_repo_commit_files = GithubRepoCommitFiles.objects.filter(
                     github_id=old_owner)
-                github_repo_commits = GithubRepoCommits.objects.filter(
-                    github_id=old_owner)
-                github_repo_commits2 = GithubRepoCommits.objects.filter(
-                    author_github=old_owner)
                 github_repo_contributors = GithubRepoContributor.objects.filter(
                     github_id=old_owner)
                 github_repo_contributors2 = GithubRepoContributor.objects.filter(
                     owner_id=old_owner)
-                github_repo_stats = GithubRepoStats.objects.filter(
-                    github_id=old_owner)
                 github_repo_stats_yymm = GithubRepoStatsyymm.objects.filter(
                     github_id=old_owner)
                 github_scores = GithubScore.objects.filter(github_id=old_owner)
@@ -678,15 +669,10 @@ class GithubIdChangeView(APIView):
                 students.update(github_id=new_owner)
                 student_tabs.update(github_id=new_owner)
                 account.update(github_id=new_owner)
-                github_issues.update(github_id=new_owner)
                 github_overview.update(github_id=new_owner)
-                github_pulls.update(github_id=new_owner)
                 github_repo_commit_files.update(github_id=new_owner)
-                github_repo_commits.update(github_id=new_owner)
-                github_repo_commits2.update(author_github=new_owner)
                 github_repo_contributors.update(github_id=new_owner)
                 github_repo_contributors2.update(owner_id=new_owner)
-                github_repo_stats.update(github_id=new_owner)
                 github_repo_stats_yymm.update(github_id=new_owner)
                 github_stars.update(github_id=new_owner)
                 github_stats_yymm.update(github_id=new_owner)

--- a/osp/repository/models.py
+++ b/osp/repository/models.py
@@ -16,7 +16,7 @@ class GithubRepoCommits(models.Model):
 
     class Meta:
         managed = False
-        db_table = 'github_repo_commits'
+        db_table = 'v_github_repo_commits'
         unique_together = (('github_id', 'repo_name', 'sha'),)
 
 


### PR DESCRIPTION
📌 PR 개요
월별 기여내역 "최근 커밋일자"의 데이터 소스를 Scrapy(github_repo_commits)에서 Spring(v_github_repo_commits VIEW)으로 교체하고, GitHub ID 변경 기능에서 VIEW 대상 UPDATE 호출로 인한 잠재적 에러를 수정합니다.

🛠 작업 내용
 GithubRepoCommits 모델의 db_table을 github_repo_commits → v_github_repo_commits로 변경
Spring github_commit + github_repository + github_account JOIN으로 OSP 호환 컬럼 제공
최근 커밋일자(committer_date)가 Spring 수집 데이터 기준으로 표시됨
 GithubIdChangeView에서 VIEW 대상 .update() 호출 제거
v_github_issues, v_github_pulls, v_github_repo_commits, v_github_repo_stats는 MySQL VIEW라 UPDATE 불가
Spring 구조에서는 github_account.github_login_username 변경 시 VIEW가 자동 반영하므로 별도 UPDATE 불필요

🖼 스크린샷 (선택)

🔗 연관된 이슈
closes #

❓ 기타 의견
v_github_repo_commits VIEW는 Spring DB에 미리 생성되어 있어야 합니다. Spring github-schema.sql에 VIEW 정의가 추가되었으므로 Spring 재배포 시 자동 반영됩니다.