### PR TITLE
fix: Spring 백엔드 호환을 위한 owner_name 추가 및 커밋 시간 KST 변환 제거

### DIFF
--- a/osp/repository/models.py
+++ b/osp/repository/models.py
@@ -3,6 +3,7 @@ from django.db import models
 
 class GithubRepoCommits(models.Model):
     github_id = models.CharField(primary_key=True, max_length=40)
+    owner_name = models.CharField(max_length=255, blank=True, null=True)
     repo_name = models.CharField(max_length=100)
     sha = models.CharField(max_length=40)
     additions = models.IntegerField()

--- a/osp/user/update_act.py
+++ b/osp/user/update_act.py
@@ -52,11 +52,11 @@ def update_commmit_time():
     start = time.time()
 
     def time_to_seconds(hour_min_sec):
-        # UTC + 9 => KST
+        # Spring이 KST로 저장하므로 변환 없이 그대로 사용
         time_t = datetime.strptime(
             str(hour_min_sec), '%Y-%m-%d %H:%M:%S').strftime('%H:%M:%S')
         hhmmss = time_t.split(':')
-        hour = (int(hhmmss[0]) + 9) % 24
+        hour = int(hhmmss[0])
         minute = int(hhmmss[1])
         sec = int(hhmmss[2])
         return hour*3600 + minute*60 + sec

--- a/osp/user/views.py
+++ b/osp/user/views.py
@@ -176,7 +176,7 @@ class GuidelineView(APIView):
                     repos[commit_repo_name]['github_id'] = commit['github_id']
                     repos[commit_repo_name]['committer_date'] = commit['committer_date']
                     id_reponame_pair_list.append(
-                        (commit['github_id'], commit_repo_name))
+                        (commit['owner_name'], commit_repo_name))
             ctx_repo_stats = []
             if len(id_reponame_pair_list) > 0:
                 contr_repo_queryset = GithubRepoStats.objects.extra(
@@ -648,7 +648,7 @@ class ProfileActivityView(APIView):
                     recent_repos[commit_repo_name]['github_id'] = commit['github_id']
                     recent_repos[commit_repo_name]['committer_date'] = commit['committer_date']
                     id_reponame_pair_list.append(
-                        (commit['github_id'], commit_repo_name))
+                        (commit['owner_name'], commit_repo_name))
             if id_reponame_pair_list:
                 contr_repo_queryset = GithubRepoStats.objects.extra(
                     where=["(github_id, repo_name) in %s"], params=[tuple(id_reponame_pair_list)])
@@ -678,10 +678,12 @@ class ProfileActivityView(APIView):
 
 def get_commit_repos(github_id):
     repo_commiter_commits = GithubRepoCommits.objects.filter(committer_github=github_id).values(
-        "github_id", "repo_name", "committer_date").order_by("-committer_date")
+        "github_id", "owner_name", "repo_name", "committer_date").order_by("-committer_date")
     repo_author_commits = GithubRepoCommits.objects.filter(author_github=github_id).values(
-        "github_id", "repo_name", "committer_date").order_by("-committer_date")
-    repo_commits = repo_commiter_commits | repo_author_commits
+        "github_id", "owner_name", "repo_name", "committer_date").order_by("-committer_date")
+    repo_owner_commits = GithubRepoCommits.objects.filter(github_id=github_id).values(
+        "github_id", "owner_name", "repo_name", "committer_date").order_by("-committer_date")
+    repo_commits = repo_commiter_commits | repo_author_commits | repo_owner_commits
 
     return repo_commits
 


### PR DESCRIPTION
📌 PR 개요
Spring 백엔드 전환 이후 발생한 두 가지 문제를 수정합니다.

가이드라인 & 최근 기여활동 페이지에 데이터가 표시되지 않는 문제: v_github_repo_commits VIEW의 github_id가 레포 소유자 login을 반환하는 반면, v_github_repo_stats의 github_id도 owner_name이라 두 VIEW 간 매핑이 깨져 데이터를 찾지 못하는 문제 해결
대시보드 기여성향 분석(커밋 시간대) 9시간 오차 문제: Spring 백엔드가 커밋 시간을 KST로 저장하는데 기존 코드가 추가로 +9시간 변환을 적용하여 발생

🛠 작업 내용
 osp/repository/models.py: GithubRepoCommits에 owner_name 필드 추가 (v_github_repo_commits VIEW 컬럼 매핑)
 osp/user/views.py: get_commit_repos()에서 owner_name 포함 조회, ProfileRepoView/ProfileActivityView에서 repo pair를 (github_id, repo_name) → (owner_name, repo_name) 기반으로 변경
 osp/user/update_act.py: time_to_seconds()의 +9 UTC→KST 변환 제거 (Spring이 KST로 저장하므로 불필요)

🖼 스크린샷 (선택)

🔗 연관된 이슈
Spring 백엔드 전환 관련 호환성 이슈

❓ 기타 의견