### PR TITLE
fix: github_repo_contributor Spring VIEW 대체 및 커밋 수 필터 수정

### DIFF
--- a/osp/rank/views.py
+++ b/osp/rank/views.py
@@ -174,7 +174,7 @@ class RepoContrib(APIView):
                 if len(student_profile) != 1:
                     continue
                 commmit_cnt = len(GithubRepoCommits.objects.filter(
-                    github_id=owner_id,
+                    owner_name=owner_id,
                     repo_name=repo_name,
                     committer_github=student.github_id
                 ))
@@ -275,7 +275,7 @@ def repo_api(request):
         if len(student_profile) != 1:
             continue
         commmit_cnt = len(GithubRepoCommits.objects.filter(
-            github_id=owner_id,
+            owner_name=owner_id,
             repo_name=repo_name,
             committer_github=student.github_id
         ))

--- a/osp/repository/models.py
+++ b/osp/repository/models.py
@@ -28,7 +28,7 @@ class GithubRepoContributor(models.Model):
 
     class Meta:
         managed = False
-        db_table = 'github_repo_contributor'
+        db_table = 'v_github_repo_contributor'
         unique_together = (('github_id', 'repo_name', 'owner_id'),)
 
 


### PR DESCRIPTION
📌 PR 개요
github_repo_contributor 테이블을 Spring 백엔드 기반 VIEW로 대체하고, 랭킹 페이지 학생 기여 정보 모달의 커밋 수 조회 필터를 수정합니다.

🛠 작업 내용
 osp/repository/models.py: GithubRepoContributor db_table을 github_repo_contributor → v_github_repo_contributor로 변경
Spring github_account_repository + github_account + github_repository JOIN 기반 VIEW로 대체
 osp/rank/views.py: GithubRepoCommits 필터를 github_id=owner_id → owner_name=owner_id로 수정
v_github_repo_commits의 github_id는 커밋 작성자 login이므로, 레포 소유자 기준 조회는 owner_name 사용해야 함
기존 코드에서 Commits가 항상 0으로 표시되던 문제 수정

🖼 스크린샷 (선택)
N/A

🔗 연관된 이슈
Spring 백엔드 전환 관련 호환성 이슈

❓ 기타 의견
