### PR TITLE
feat: GithubIdChange 시 Spring API 호출하여 github_login_username 동기화

### DIFF
--- a/osp/common/views.py
+++ b/osp/common/views.py
@@ -3,6 +3,7 @@ import re
 import smtplib
 
 import requests
+from django.conf import settings
 from django.contrib.auth import authenticate, get_user_model, logout
 from django.contrib.auth.models import User
 from django.contrib.auth.tokens import default_token_generator
@@ -680,6 +681,23 @@ class GithubIdChangeView(APIView):
                 github_user_scoretable.update(github_id=new_owner)
                 github_user_followings.update(github_id=new_owner)
                 github_user_followings2.update(following_id=new_owner)
+
+                # Spring DB 동기화: github_account.github_login_username 업데이트
+                # VIEW(v_github_repo_commits 등)가 github_login_username 기준으로 JOIN하므로
+                # Spring 쪽도 함께 변경해야 데이터 불일치가 발생하지 않음
+                student_id = data.get('student_data')
+                spring_url = getattr(settings, 'SPRING_BACKEND_URL', 'http://localhost:8080')
+                try:
+                    spring_res = requests.patch(
+                        f"{spring_url}/api/v1/github-account/{student_id}/username",
+                        json={"newUsername": new_owner},
+                        timeout=10
+                    )
+                    spring_data = spring_res.json()
+                    if not spring_data.get('success'):
+                        logging.warning(f"GithubIdChangeView Spring 동기화 실패: studentId={student_id}, res={spring_data}")
+                except Exception as spring_e:
+                    logging.warning(f"GithubIdChangeView Spring API 호출 실패 (무시하고 계속): {spring_e}")
 
                 for score in github_scores:
                     year = score.year


### PR DESCRIPTION
📌 PR 개요
OSP에서 사용자의 GitHub ID(username)를 변경할 때, Spring DB와 동기화하지 않아 VIEW 기반 화면에서 데이터가 누락되는 문제를 수정합니다.

🛠 작업 내용
 GithubIdChangeView에서 OSP 테이블 업데이트 완료 후 Spring PATCH API(/api/v1/github-account/{studentId}/username) 호출하여 github_account.github_login_username 동기화
 Spring API 호출 실패 시 경고 로그만 남기고 OSP 업데이트는 정상 완료되도록 격리 (Spring 장애가 github_id 변경 전체를 롤백시키지 않도록)
 common/views.py에 django.conf.settings import 추가
🔗 연관된 이슈
없음

❓ 기타 의견
문제 배경
OSP와 Spring은 같은 DB를 공유하지 않고, VIEW(v_github_repo_commits 등)를 통해 연동됩니다. VIEW는 Spring의 github_account.github_login_username을 JOIN 조건으로 사용하는데, OSP가 자체 테이블만 업데이트하면 Spring 쪽 원본이 구버전 username을 유지해 VIEW 조회 시 데이터 누락이 발생합니다.

Spring 측 작업
feat/github-account-username-update-api 브랜치에서 PATCH /api/v1/github-account/{studentId}/username 엔드포인트를 추가했습니다. 해당 PR과 함께 배포되어야 합니다.