### PR TITLE
feat: OSP 회원가입 시 Spring DB에 유저 자동 등록

### DIFF
--- a/osp/common/views.py
+++ b/osp/common/views.py
@@ -33,6 +33,40 @@ from django.views.decorators.csrf import csrf_exempt
 from django.utils.decorators import method_decorator
 
 
+def _register_to_spring(student_id, name, college, dept, absence, plural_major, github_id, email):
+    """OSP 회원가입 완료 후 Spring DB에 유저 등록"""
+    try:
+        gh_res = requests.get(f'https://api.github.com/users/{github_id}', timeout=10)
+        if gh_res.status_code != 200:
+            logging.warning(f'Spring 등록 실패: GitHub API 조회 실패 ({github_id})')
+            return
+        gh_data = gh_res.json()
+        numeric_id = gh_data.get('id')
+        node_id = gh_data.get('node_id')
+
+        spring_url = getattr(settings, 'SPRING_BACKEND_URL', 'http://localhost:8080')
+        payload = {
+            'studentId': str(student_id),
+            'name': name,
+            'college': college,
+            'dept': dept,
+            'absence': absence,
+            'pluralMajor': plural_major,
+            'githubId': numeric_id,
+            'githubGraphqlNodeId': node_id,
+            'githubLoginUsername': github_id,
+            'githubName': github_id,
+            'githubEmail': email,
+        }
+        res = requests.post(f'{spring_url}/api/auth/signup', json=payload, timeout=10)
+        if res.status_code == 200:
+            logging.info(f'Spring 등록 완료: studentId={student_id}, github={github_id}')
+        else:
+            logging.warning(f'Spring 등록 실패: status={res.status_code}, body={res.text}')
+    except Exception as e:
+        logging.warning(f'Spring 등록 중 오류 (무시): {e}')
+
+
 @method_decorator(csrf_exempt, name='dispatch')
 class JWTLoginView(APIView):
     def post(self, request):
@@ -292,6 +326,11 @@ class SignUpView(APIView):
         except DatabaseError as e:
             print('SignUpView 데이터베이스 오류.', e)
             return Response({'status': 'fail', 'message': '데이터베이스에 문제가 발생했습니다.'})
+
+        _register_to_spring(student_id, name, college, dept,
+                            request.data.get('absence', 0),
+                            request.data.get('plural_major', 0),
+                            github_id, personal_email)
 
         return Response({'status': 'success'})
 


### PR DESCRIPTION
📌 PR 개요
OSP 신규 회원가입 시 Spring DB에 유저가 등록되지 않아 GitHub 데이터 수집 대상에서 누락되는 문제를 수정했습니다.

🛠 작업 내용
 SignUpView.post() 완료 후 _register_to_spring() 함수 호출 추가
 _register_to_spring(): GitHub API로 numeric ID / node_id 조회 후 Spring /api/auth/signup 호출하여 Spring DB(student_account, github_account)에 동기화
 Spring 등록 실패 시에도 OSP 가입은 정상 처리 (best-effort, 예외 무시)
🔍 문제 원인
Spring 수집기는 자체 student_account / github_account 테이블을 기준으로 6시간마다 GitHub 데이터를 수집합니다. 그런데 OSP 회원가입 시 이 테이블에 유저가 추가되지 않아, 신규 가입자의 GitHub 활동이 대시보드에 반영되지 않는 문제가 있었습니다.

🔗 연관된 이슈
신규 가입자 대시보드 미연동 문의 (aniseongu 외 다수)