### PR TITLE
Develop

### DIFF
--- a/osp/common/views.py
+++ b/osp/common/views.py
@@ -33,6 +33,40 @@ from django.views.decorators.csrf import csrf_exempt
 from django.utils.decorators import method_decorator
 
 
+def _register_to_spring(student_id, name, college, dept, absence, plural_major, github_id, email):
+    """OSP 회원가입 완료 후 Spring DB에 유저 등록"""
+    try:
+        gh_res = requests.get(f'https://api.github.com/users/{github_id}', timeout=10)
+        if gh_res.status_code != 200:
+            logging.warning(f'Spring 등록 실패: GitHub API 조회 실패 ({github_id})')
+            return
+        gh_data = gh_res.json()
+        numeric_id = gh_data.get('id')
+        node_id = gh_data.get('node_id')
+
+        spring_url = getattr(settings, 'SPRING_BACKEND_URL', 'http://localhost:8080')
+        payload = {
+            'studentId': str(student_id),
+            'name': name,
+            'college': college,
+            'dept': dept,
+            'absence': absence,
+            'pluralMajor': plural_major,
+            'githubId': numeric_id,
+            'githubGraphqlNodeId': node_id,
+            'githubLoginUsername': github_id,
+            'githubName': github_id,
+            'githubEmail': email,
+        }
+        res = requests.post(f'{spring_url}/api/auth/signup', json=payload, timeout=10)
+        if res.status_code == 200:
+            logging.info(f'Spring 등록 완료: studentId={student_id}, github={github_id}')
+        else:
+            logging.warning(f'Spring 등록 실패: status={res.status_code}, body={res.text}')
+    except Exception as e:
+        logging.warning(f'Spring 등록 중 오류 (무시): {e}')
+
+
 @method_decorator(csrf_exempt, name='dispatch')
 class JWTLoginView(APIView):
     def post(self, request):
@@ -292,6 +326,11 @@ class SignUpView(APIView):
         except DatabaseError as e:
             print('SignUpView 데이터베이스 오류.', e)
             return Response({'status': 'fail', 'message': '데이터베이스에 문제가 발생했습니다.'})
+
+        _register_to_spring(student_id, name, college, dept,
+                            request.data.get('absence', 0),
+                            request.data.get('plural_major', 0),
+                            github_id, personal_email)
 
         return Response({'status': 'success'})
 

--- a/osp/common/views.py
+++ b/osp/common/views.py
@@ -25,7 +25,7 @@ from osp.settings import (EMAIL_HOST_USER, GITHUB_CLIENT_ID,
 from tag.models import TagIndependent
 from tag.serializers import TagIndependentSerializer
 from user.models import Account, AccountInterest, AccountPrivacy, StudentTab, GitHubScoreTable, GithubScore, GithubStatsYymm, GithubUserFollowing, GithubUserStarred, GithubOverview
-from repository.models import GithubIssues, GithubPulls, GithubRepoCommits, GithubRepoContributor, GithubRepoStats, GithubRepoCommitFiles, GithubRepoStatsyymm, GithubStars
+from repository.models import GithubRepoContributor, GithubRepoCommitFiles, GithubRepoStatsyymm, GithubStars
 from home.models import Repository, Student
 from data.api import GitHub_API
 from django.views.decorators.csrf import csrf_exempt
@@ -641,23 +641,14 @@ class GithubIdChangeView(APIView):
                 students = Student.objects.filter(github_id=old_owner)
                 student_tabs = StudentTab.objects.filter(github_id=old_owner)
                 account = Account.objects.filter(github_id=old_owner)
-                github_issues = GithubIssues.objects.filter(
-                    github_id=old_owner)
                 github_overview = GithubOverview.objects.filter(
                     github_id=old_owner)
-                github_pulls = GithubPulls.objects.filter(github_id=old_owner)
                 github_repo_commit_files = GithubRepoCommitFiles.objects.filter(
                     github_id=old_owner)
-                github_repo_commits = GithubRepoCommits.objects.filter(
-                    github_id=old_owner)
-                github_repo_commits2 = GithubRepoCommits.objects.filter(
-                    author_github=old_owner)
                 github_repo_contributors = GithubRepoContributor.objects.filter(
                     github_id=old_owner)
                 github_repo_contributors2 = GithubRepoContributor.objects.filter(
                     owner_id=old_owner)
-                github_repo_stats = GithubRepoStats.objects.filter(
-                    github_id=old_owner)
                 github_repo_stats_yymm = GithubRepoStatsyymm.objects.filter(
                     github_id=old_owner)
                 github_scores = GithubScore.objects.filter(github_id=old_owner)
@@ -678,15 +669,10 @@ class GithubIdChangeView(APIView):
                 students.update(github_id=new_owner)
                 student_tabs.update(github_id=new_owner)
                 account.update(github_id=new_owner)
-                github_issues.update(github_id=new_owner)
                 github_overview.update(github_id=new_owner)
-                github_pulls.update(github_id=new_owner)
                 github_repo_commit_files.update(github_id=new_owner)
-                github_repo_commits.update(github_id=new_owner)
-                github_repo_commits2.update(author_github=new_owner)
                 github_repo_contributors.update(github_id=new_owner)
                 github_repo_contributors2.update(owner_id=new_owner)
-                github_repo_stats.update(github_id=new_owner)
                 github_repo_stats_yymm.update(github_id=new_owner)
                 github_stars.update(github_id=new_owner)
                 github_stats_yymm.update(github_id=new_owner)

--- a/osp/common/views.py
+++ b/osp/common/views.py
@@ -3,6 +3,7 @@ import re
 import smtplib
 
 import requests
+from django.conf import settings
 from django.contrib.auth import authenticate, get_user_model, logout
 from django.contrib.auth.models import User
 from django.contrib.auth.tokens import default_token_generator
@@ -680,6 +681,23 @@ class GithubIdChangeView(APIView):
                 github_user_scoretable.update(github_id=new_owner)
                 github_user_followings.update(github_id=new_owner)
                 github_user_followings2.update(following_id=new_owner)
+
+                # Spring DB 동기화: github_account.github_login_username 업데이트
+                # VIEW(v_github_repo_commits 등)가 github_login_username 기준으로 JOIN하므로
+                # Spring 쪽도 함께 변경해야 데이터 불일치가 발생하지 않음
+                student_id = data.get('student_data')
+                spring_url = getattr(settings, 'SPRING_BACKEND_URL', 'http://localhost:8080')
+                try:
+                    spring_res = requests.patch(
+                        f"{spring_url}/api/v1/github-account/{student_id}/username",
+                        json={"newUsername": new_owner},
+                        timeout=10
+                    )
+                    spring_data = spring_res.json()
+                    if not spring_data.get('success'):
+                        logging.warning(f"GithubIdChangeView Spring 동기화 실패: studentId={student_id}, res={spring_data}")
+                except Exception as spring_e:
+                    logging.warning(f"GithubIdChangeView Spring API 호출 실패 (무시하고 계속): {spring_e}")
 
                 for score in github_scores:
                     year = score.year

--- a/osp/rank/views.py
+++ b/osp/rank/views.py
@@ -174,7 +174,7 @@ class RepoContrib(APIView):
                 if len(student_profile) != 1:
                     continue
                 commmit_cnt = len(GithubRepoCommits.objects.filter(
-                    github_id=owner_id,
+                    owner_name=owner_id,
                     repo_name=repo_name,
                     committer_github=student.github_id
                 ))
@@ -275,7 +275,7 @@ def repo_api(request):
         if len(student_profile) != 1:
             continue
         commmit_cnt = len(GithubRepoCommits.objects.filter(
-            github_id=owner_id,
+            owner_name=owner_id,
             repo_name=repo_name,
             committer_github=student.github_id
         ))

--- a/osp/repository/models.py
+++ b/osp/repository/models.py
@@ -54,7 +54,7 @@ class GithubRepoStats(models.Model):
 
     class Meta:
         managed = False
-        db_table = 'github_repo_stats'
+        db_table = 'v_github_repo_stats'
         unique_together = (('github_id', 'repo_name'),)
 
     def get_guideline(self):
@@ -103,7 +103,7 @@ class GithubIssues(models.Model):
 
     class Meta:
         managed = False
-        db_table = 'github_issues'
+        db_table = 'v_github_issues'
         unique_together = (('owner_id', 'repo_name', 'number'),)
 
 
@@ -117,7 +117,7 @@ class GithubPulls(models.Model):
 
     class Meta:
         managed = False
-        db_table = 'github_pulls'
+        db_table = 'v_github_pulls'
         unique_together = (('owner_id', 'repo_name', 'number'),)
 
 

--- a/osp/repository/models.py
+++ b/osp/repository/models.py
@@ -3,6 +3,7 @@ from django.db import models
 
 class GithubRepoCommits(models.Model):
     github_id = models.CharField(primary_key=True, max_length=40)
+    owner_name = models.CharField(max_length=255, blank=True, null=True)
     repo_name = models.CharField(max_length=100)
     sha = models.CharField(max_length=40)
     additions = models.IntegerField()

--- a/osp/repository/models.py
+++ b/osp/repository/models.py
@@ -28,7 +28,7 @@ class GithubRepoContributor(models.Model):
 
     class Meta:
         managed = False
-        db_table = 'github_repo_contributor'
+        db_table = 'v_github_repo_contributor'
         unique_together = (('github_id', 'repo_name', 'owner_id'),)
 
 

--- a/osp/repository/models.py
+++ b/osp/repository/models.py
@@ -16,7 +16,7 @@ class GithubRepoCommits(models.Model):
 
     class Meta:
         managed = False
-        db_table = 'github_repo_commits'
+        db_table = 'v_github_repo_commits'
         unique_together = (('github_id', 'repo_name', 'sha'),)
 
 

--- a/osp/user/models.py
+++ b/osp/user/models.py
@@ -60,7 +60,7 @@ class GithubStatsYymm(models.Model):
 
     class Meta:
         managed = False
-        db_table = 'github_stats_yymm'
+        db_table = 'github_monthly_stats'
 
     def to_json(self):
         return {

--- a/osp/user/update_act.py
+++ b/osp/user/update_act.py
@@ -52,11 +52,11 @@ def update_commmit_time():
     start = time.time()
 
     def time_to_seconds(hour_min_sec):
-        # UTC + 9 => KST
+        # Spring이 KST로 저장하므로 변환 없이 그대로 사용
         time_t = datetime.strptime(
             str(hour_min_sec), '%Y-%m-%d %H:%M:%S').strftime('%H:%M:%S')
         hhmmss = time_t.split(':')
-        hour = (int(hhmmss[0]) + 9) % 24
+        hour = int(hhmmss[0])
         minute = int(hhmmss[1])
         sec = int(hhmmss[2])
         return hour*3600 + minute*60 + sec

--- a/osp/user/views.py
+++ b/osp/user/views.py
@@ -176,7 +176,7 @@ class GuidelineView(APIView):
                     repos[commit_repo_name]['github_id'] = commit['github_id']
                     repos[commit_repo_name]['committer_date'] = commit['committer_date']
                     id_reponame_pair_list.append(
-                        (commit['github_id'], commit_repo_name))
+                        (commit['owner_name'], commit_repo_name))
             ctx_repo_stats = []
             if len(id_reponame_pair_list) > 0:
                 contr_repo_queryset = GithubRepoStats.objects.extra(
@@ -648,7 +648,7 @@ class ProfileActivityView(APIView):
                     recent_repos[commit_repo_name]['github_id'] = commit['github_id']
                     recent_repos[commit_repo_name]['committer_date'] = commit['committer_date']
                     id_reponame_pair_list.append(
-                        (commit['github_id'], commit_repo_name))
+                        (commit['owner_name'], commit_repo_name))
             if id_reponame_pair_list:
                 contr_repo_queryset = GithubRepoStats.objects.extra(
                     where=["(github_id, repo_name) in %s"], params=[tuple(id_reponame_pair_list)])
@@ -678,10 +678,12 @@ class ProfileActivityView(APIView):
 
 def get_commit_repos(github_id):
     repo_commiter_commits = GithubRepoCommits.objects.filter(committer_github=github_id).values(
-        "github_id", "repo_name", "committer_date").order_by("-committer_date")
+        "github_id", "owner_name", "repo_name", "committer_date").order_by("-committer_date")
     repo_author_commits = GithubRepoCommits.objects.filter(author_github=github_id).values(
-        "github_id", "repo_name", "committer_date").order_by("-committer_date")
-    repo_commits = repo_commiter_commits | repo_author_commits
+        "github_id", "owner_name", "repo_name", "committer_date").order_by("-committer_date")
+    repo_owner_commits = GithubRepoCommits.objects.filter(github_id=github_id).values(
+        "github_id", "owner_name", "repo_name", "committer_date").order_by("-committer_date")
+    repo_commits = repo_commiter_commits | repo_author_commits | repo_owner_commits
 
     return repo_commits
 

--- a/osp/user/views.py
+++ b/osp/user/views.py
@@ -836,9 +836,9 @@ def get_user_star(github_id: str):
     star_subquery = Subquery(StudentTab.objects.values('github_id'))
     # repo_name, owner_id, github_id 값 비교
     where_stmt = [
-        "github_repo_contributor.repo_name=github_repo_stats.repo_name",
-        "github_repo_contributor.owner_id=github_repo_stats.github_id",
-        "github_repo_contributor.github_id=github_repo_stats.github_id"]
+        "github_repo_contributor.repo_name=v_github_repo_stats.repo_name",
+        "github_repo_contributor.owner_id=v_github_repo_stats.github_id",
+        "github_repo_contributor.github_id=v_github_repo_stats.github_id"]
     star_data = GithubRepoStats.objects.filter(github_id__in=star_subquery).extra(
         tables=['github_repo_contributor'], where=where_stmt).values('github_id').annotate(star=Sum("stargazers_count"))
     total_stars = sum(item['star'] for item in star_data)


### PR DESCRIPTION
📌 PR 개요
OSP 신규 회원가입 시 Spring DB에 유저가 등록되지 않아 GitHub 데이터 수집 대상에서 누락되는 문제를 수정했습니다.

🛠 작업 내용
 common/views.py SignUpView.post() 완료 후 _register_to_spring() 호출 추가
 _register_to_spring() 함수 구현: GitHub API로 numeric ID / node_id 조회 후 Spring /api/auth/signup 호출하여 Spring student_account / github_account 테이블에 동기화
 Spring 등록 실패 시에도 OSP 가입은 정상 처리 (best-effort, 예외 무시)
🔍 문제 원인
Spring 수집기는 자체 student_account / github_account 테이블을 기준으로 6시간마다 GitHub 데이터를 수집합니다. OSP 회원가입 시 이 테이블에 유저가 추가되지 않아, 신규 가입자의 GitHub 활동이 대시보드에 영구적으로 반영되지 않는 문제가 있었습니다.

❓ 기타 의견
이미 가입되어 있으나 Spring DB에 누락된 기존 유저는 수동으로 Spring API(POST /api/auth/signup)를 호출하여 등록해야 합니다.
