### PR TITLE
fix: litellm 버전 고정 및 typing_extensions 추가 (Python 3.9 호환)

### DIFF
--- a/osp/deploy/requirements.txt
+++ b/osp/deploy/requirements.txt
@@ -55,5 +55,6 @@ virtualenvwrapper==4.8.4
 webdriver-manager
 Werkzeug==2.1.2
 zipp==3.8.0
-litellm
+litellm>=1.0.0
+typing_extensions>=4.6.0
 


### PR DESCRIPTION
litellm 미지정 시 0.x가 설치되어 aiosignal 버전 충돌 발생.
litellm>=1.0.0으로 고정하고 typing_extensions>=4.6.0 추가.

## 📌 PR 개요

간단한 요약을 적어주세요 (예: 어떤 기능을 추가했는지, 어떤 문제를 해결했는지 등)

## 🛠 작업 내용

- [ ] 작업한 항목 1
- [ ] 작업한 항목 2

## 🖼 스크린샷 (선택)

PR 이해를 돕는 스크린샷 첨부

## 🔗 연관된 이슈

- closes #이슈번호

## ❓ 기타 의견
